### PR TITLE
Added possibility to set sourceRoot relative to current work directory

### DIFF
--- a/packages/plugin/src/classes/helpers/classes.js
+++ b/packages/plugin/src/classes/helpers/classes.js
@@ -271,7 +271,9 @@ export function getClassInfo(path, node, parent, pluginOpts) {
 function getFileBaseNamespace(path, pluginOpts) {
   const opts = path.hub.file.opts;
   const filename = Path.resolve(opts.filename);
-  const sourceRoot = opts.sourceRoot || process.cwd();
+  const sourceRoot = opts.sourceRoot
+    ? Path.resolve(process.cwd(), opts.sourceRoot)
+    : process.cwd();
   if (filename.startsWith(sourceRoot)) {
     const filenameRelative = Path.relative(sourceRoot, filename);
     const { dir } = Path.parse(filenameRelative);


### PR DESCRIPTION
Currently, the sourceRoot parameter in the .babelrc.json must be absolute. Here it would make more sense to evaluate the parameter relative to the current working directory.