### PR TITLE
Find associated JSDoc when preceding a named export

### DIFF
--- a/packages/plugin/__test__/__snapshots__/test.js.snap
+++ b/packages/plugin/__test__/__snapshots__/test.js.snap
@@ -382,6 +382,13 @@ exports[`classes class-convert-jsdoc-name.js 1`] = `
 });"
 `;
 
+exports[`classes class-convert-jsdoc-named-and-default-export.js 1`] = `
+"sap.ui.define([\\"sap/SAPClass\\"], function (SAPClass) {
+  const MyClass = SAPClass.extend(\\"x.y.MyClass\\", {});
+  return MyClass;
+});"
+`;
+
 exports[`classes class-convert-jsdoc-namespace.controller.js 1`] = `
 "sap.ui.define([\\"sap/SAPClass\\"], function (SAPClass) {
   const MyClass = SAPClass.extend(\\"x.y.MyClass\\", {});

--- a/packages/plugin/__test__/fixtures/classes/class-convert-jsdoc-named-and-default-export.js
+++ b/packages/plugin/__test__/fixtures/classes/class-convert-jsdoc-named-and-default-export.js
@@ -1,0 +1,8 @@
+import SAPClass from "sap/SAPClass";
+
+/**
+ * @namespace x.y
+ */
+export class MyClass extends SAPClass { }
+
+export default MyClass;

--- a/packages/plugin/src/classes/helpers/jsdoc.js
+++ b/packages/plugin/src/classes/helpers/jsdoc.js
@@ -31,11 +31,12 @@ export function getJsDocClassInfo(node, parent) {
       })
       .filter(notEmpty)[0];
   }
-  // Else see if the JSDoc are on the return statement (eg. return class X extends SAPClass)
-  // or export statement (eg. export default class X extends SAPClass)
+  // Else see if the JSDoc are on the return statement (eg. 'return class X extends SAPClass')
+  // or export statement (eg. 'export default class X extends SAPClass' or 'export class X extends SAPClass')
   else if (
     (t.isClassExpression(node) && t.isReturnStatement(parent)) ||
-    (t.isClassDeclaration(node) && t.isExportDefaultDeclaration(parent))
+    (t.isClassDeclaration(node) && t.isExportDefaultDeclaration(parent)) ||
+    (t.isClassDeclaration(node) && t.isExportNamedDeclaration(parent))
   ) {
     return getJsDocClassInfo(parent);
   } else {


### PR DESCRIPTION
The JSDoc comment defining a namespace etc. assigned to a class is found
when preceding a default export statement which wraps the class
definition. But it is so far not found when the export statement is a
*named* export.

Why is this required? For custom control development, UI5 is about to
provide a tool that generates the method declarations for the methods
generated at runtime. The methods are generated as an interface in a
separate file. Due to equal names, TypeScript merges the interface with
the class. But the (control) class must also be a named export in
addition to the regular default export, in order to make this mechanism
work. Hence, controls shall be written like this:

/**
 * @namespace x.y
 */
export class MyControl extends Control {
 ...
};
export default MyControl;

This change allows the preceding JSDoc to be found and considered.