### PR TITLE
Introduce JSDoc annotation denoting named exports as design-time only

### DIFF
--- a/packages/plugin/src/classes/helpers/jsdoc.js
+++ b/packages/plugin/src/classes/helpers/jsdoc.js
@@ -101,6 +101,20 @@ export function hasJsdocGlobalExportFlag(node) {
   });
 }
 
+export function hasJsdocDesigntimeOnlyExportFlag(node) {
+  if (!node.leadingComments) {
+    return false;
+  }
+  return node.leadingComments.filter(isCommentBlock).some(comment => {
+    return (
+      doctrine.parse(comment.value, {
+        unwrap: true,
+        tags: ["ui5designtimeonlyexport"],
+      }).tags.length > 0
+    );
+  });
+}
+
 // This doesn't exist on babel-types
 function isCommentBlock(node) {
   return node && node.type === "CommentBlock";

--- a/packages/plugin/src/modules/helpers/exports.js
+++ b/packages/plugin/src/modules/helpers/exports.js
@@ -28,6 +28,7 @@ export function collapseNamedExports(
     defaultExport,
     namedExports
   );
+  namedExports = filterOutDesignTimeOnlyNamedExports(namedExports);
   if (!namedExports.length || opts.noExportExtend) {
     return {
       filteredExports: namedExports,
@@ -113,6 +114,10 @@ function filterOutExportsWhichAlreadyMatchPropsOnDefault(
   }
 
   return namedExports;
+}
+
+function filterOutDesignTimeOnlyNamedExports(namedExports) {
+  return namedExports.filter(namedExport => !namedExport.annotations || !namedExport.annotations.designTimeOnly);
 }
 
 function areSame(defaultExportProperty, matchingNamedExport) {

--- a/packages/plugin/src/modules/visitor.js
+++ b/packages/plugin/src/modules/visitor.js
@@ -2,12 +2,13 @@ import { types as t } from "@babel/core";
 import * as th from "../utils/templates";
 import * as ast from "../utils/ast";
 
-import { hasJsdocGlobalExportFlag } from "../classes/helpers/jsdoc";
+import { hasJsdocGlobalExportFlag, hasJsdocDesigntimeOnlyExportFlag } from "../classes/helpers/jsdoc";
 
 const tempModuleName = name => `__${name}`;
 const cleanImportSource = src =>
   src.replace(/(\/)|(-)|(@)/g, "_").replace(/\./g, "");
 const hasGlobalExportFlag = node => hasJsdocGlobalExportFlag(node);
+const hasDesigntimeOnlyExportFlag = node => hasJsdocDesigntimeOnlyExportFlag(node);
 
 export const ModuleTransformVisitor = {
   /*!
@@ -171,6 +172,7 @@ export const ModuleTransformVisitor = {
         this.namedExports.push({
           key: specifier.exported,
           value: t.identifier(`${fromSource}${specifier.local.name}`),
+          annotations: { designTimeOnly: hasDesigntimeOnlyExportFlag(node) }
         });
       }
       path.remove();


### PR DESCRIPTION
Using a JSDoc comment with the newly introduced custom tag
@ui5designtimeonlyexport the subsequent named export can be marked as
"design-time only". This means it is only needed during development time
for certain TypeScript mechanisms, but should not be present at runtime.

This implements a proposal discussed in
https://github.com/r-murphy/babel-plugin-transform-modules-ui5/pull/66
to make the overall solution discussed in
https://github.com/SAP/ui5-typescript/issues/294
prettier:
For module merging needed in UI5 control development, the control class
name needs to be a named export (in addition to being the default
export). This is only needed at development time to make the TypeScript
compiler recognize the additionally generated interface as enriching the
control class.