### PR TITLE
Make noWrapBeforeImport work also with no deconstructors

### DIFF
--- a/packages/plugin/__test__/__snapshots__/test.js.snap
+++ b/packages/plugin/__test__/__snapshots__/test.js.snap
@@ -1230,6 +1230,16 @@ sap.ui.define([\\"./foo\\"], function (__Foo) {
 });"
 `;
 
+exports[`min-wrap min-wrap-ui5.js 1`] = `
+"\\"use strict\\";
+
+const x = 1;
+sap.ui.define([\\"sap/m/Button\\"], function (Button) {
+  const b = new Button();
+  return b;
+});"
+`;
+
 exports[`mixed mixed-import-export.js 1`] = `
 "sap.ui.define([\\"1\\", \\"2\\", \\"3\\", \\"4\\", \\"5\\"], function (__1, __2, __3, __4, __5) {
   var __exports = {

--- a/packages/plugin/__test__/fixtures/min-wrap/min-wrap-ui5.js
+++ b/packages/plugin/__test__/fixtures/min-wrap/min-wrap-ui5.js
@@ -1,0 +1,7 @@
+const x = 1; // This should not be part of sap-ui-define
+
+import Button from "sap/m/Button";
+
+const b = new Button();
+
+export default b;

--- a/packages/plugin/src/modules/helpers/wrapper.js
+++ b/packages/plugin/src/modules/helpers/wrapper.js
@@ -7,7 +7,7 @@ export function wrap(visitor, programNode, opts) {
   let {
     defaultExport,
     exportGlobal,
-    firstImport,
+    firstImportMarked,
     imports,
     namedExports,
     ignoredImports,
@@ -59,18 +59,19 @@ export function wrap(visitor, programNode, opts) {
   const preDefine = [...ignoredImports];
   // If the noWrapBeforeImport opt is set, split any code before the first import and afterwards into separate arrays.
   // This should be done before any interops or other vars are injected.
-  if (opts.noWrapBeforeImport && firstImport) {
+  if (opts.noWrapBeforeImport && firstImportMarked) {
     let reachedFirstImport = false;
     const fullBody = body;
     const newBody = [];
+
     for (const item of fullBody) {
-      if (item === firstImport) {
-        reachedFirstImport = true;
-      }
       if (reachedFirstImport) {
         newBody.push(item);
       } else {
         preDefine.push(item);
+      }
+      if (item.lastBeforeWrapping) {
+        reachedFirstImport = true;
       }
     }
     if (preDefine.length && !hasUseStrict(programNode)) {

--- a/packages/plugin/src/modules/visitor.js
+++ b/packages/plugin/src/modules/visitor.js
@@ -127,6 +127,13 @@ export const ModuleTransformVisitor = {
       }
     }
 
+    // this is the very first import in noWrapBeforeImport mode and there are sibling nodes before this import
+    if (opts.noWrapBeforeImport && !this.firstImportMarked && path.inList && path.key > 0) {
+      // mark the direct predecessor as the last one to exclude from wrapping
+      path.getSibling(path.key - 1).node.lastBeforeWrapping = true;
+      this.firstImportMarked = true;
+    }
+
     path.replaceWithMultiple(deconstructors);
 
     if (deconstructors.length) {
@@ -135,11 +142,6 @@ export const ModuleTransformVisitor = {
     }
 
     imp.deconstructors = imp.deconstructors.concat(deconstructors);
-
-    // TODO: now that we're saving deconstructors on the import, dynamically determine firstImport if needed.
-    if (!this.firstImport && imp.deconstructors[0]) {
-      this.firstImport = imp.deconstructors[0];
-    }
 
     if (!existingImport) {
       this.imports.push(imp);


### PR DESCRIPTION
This could be a fix for #80 
Do not depend on deconstructors, which only exist in interop case. Instead, in visitor.js mark the node preceding the first import (if any) in noWrapBeforeImport mode and remember that marking has happened. In wrapper.js, in case the latter info is present, do not wrap the nodes up to (and including) the marked preceding node.

This relies on the preceding node not getting removed along the way, which I hope is ok, as any processing should already have happened, but this is a point to check.