### PR TITLE
Add "overrides" to static props which go into the extend(...) object

### DIFF
--- a/packages/plugin/__test__/__snapshots__/test.js.snap
+++ b/packages/plugin/__test__/__snapshots__/test.js.snap
@@ -187,6 +187,17 @@ exports[`classes class-convert-controller-extend-static-prop.controller.js 1`] =
 });"
 `;
 
+exports[`classes class-convert-controller-extension-static-prop.controller.js 1`] = `
+"sap.ui.define([\\"sap/ui/core/mvc/ControllerExtension\\"], function (ControllerExtension) {
+  const MyExtension = ControllerExtension.extend(\\"fixtures.classes.MyExtension\\", {
+    overrides: {
+      onPageReady: function () {}
+    }
+  });
+  return MyExtension;
+});"
+`;
+
 exports[`classes class-convert-controller-multi.controller.js 1`] = `
 "sap.ui.define([\\"sap/ui/core/Controller\\", \\"other\\"], function (SAPController, __Other) {
   function _interopRequireDefault(obj) {

--- a/packages/plugin/__test__/fixtures/classes/class-convert-controller-extension-static-prop.controller.js
+++ b/packages/plugin/__test__/fixtures/classes/class-convert-controller-extension-static-prop.controller.js
@@ -1,0 +1,8 @@
+import ControllerExtension from "sap/ui/core/mvc/ControllerExtension";
+
+export default class MyExtension extends ControllerExtension {
+
+  static overrides = {
+    onPageReady: function () { }
+  }
+}

--- a/packages/plugin/src/classes/helpers/classes.js
+++ b/packages/plugin/src/classes/helpers/classes.js
@@ -55,7 +55,7 @@ export function convertClassToUI5Extend(
 
   const staticPropsToAdd = moveStaticStaticPropsToExtend
     ? Object.keys(extraStaticProps)
-    : ["metadata", "renderer"];
+    : ["metadata", "renderer", "overrides"];
 
   for (const propName of staticPropsToAdd) {
     if (extraStaticProps[propName]) {
@@ -115,8 +115,8 @@ export function convertClassToUI5Extend(
       }
     } else if (t.isClassProperty(member)) {
       if (!member.value) continue; // un-initialized static class prop (typescript)
-      if (memberName === "metadata" || memberName === "renderer") {
-        // Special handling for TypeScript limitation where metadata and renderer must be properties.
+      if (memberName === "metadata" || memberName === "renderer" || memberName === "overrides") {
+        // Special handling for TypeScript limitation where metadata, renderer and overrides must be properties.
         extendProps.unshift(buildObjectProperty(member));
       } else if (member.static) {
         if (moveStaticStaticPropsToExtend) {
@@ -180,12 +180,12 @@ export function convertClassToUI5Extend(
     const bindToId = t.identifier(bindToMethodName);
     const bindMethodDeclaration = bindToConstructor
       ? th.buildInheritingConstructor({
-          SUPER: t.identifier(superClassName),
-        })
+        SUPER: t.identifier(superClassName),
+      })
       : th.buildInheritingFunction({
-          NAME: bindToId,
-          SUPER: t.identifier(superClassName),
-        });
+        NAME: bindToId,
+        SUPER: t.identifier(superClassName),
+      });
     bindMethod = ast.convertFunctionDeclarationToExpression(
       bindMethodDeclaration
     );


### PR DESCRIPTION
This is needed for ControllerExtensions: the "overrides" block needs to go into the ControllerExtension.extend() call, not appended to the class later as a static property.

Note that the name for this definition block is still "override" in the documentation at this time. But this is about to change, because a static property "override" clashes with the method ControllerExtension.override() in TypeScript.

Contributes to fixing https://github.com/SAP/ui5-typescript/issues/332